### PR TITLE
Update simple-table.js

### DIFF
--- a/addon/components/simple-table.js
+++ b/addon/components/simple-table.js
@@ -25,7 +25,7 @@ export default Ember.Component.extend({
     }
   }),
 
-  sorting: computed('sortingCriteria.[]', 'tData.[]', {
+  sorting: computed('sortingCriteria.[]', 'tData.[]', defaultSorting, {
     get() {
       let sortingCriteria = this.get('sortingCriteria')
         .filterBy('order')


### PR DESCRIPTION
Added defaultSorting in the computed property 'sorting' .
This change is required for the case when the properties on which sorting needs to be applied is not part of table columns,  we inject the the defaultSorting , but the computed property 'sorting' is not recalculated when defaultSorting property changes and thus sorting only works for the first time in this case.